### PR TITLE
Add super resolution defense wrapper

### DIFF
--- a/DiffBreak/utils/__init__.py
+++ b/DiffBreak/utils/__init__.py
@@ -1,1 +1,4 @@
 from .wrapper import ClassifierWrapper
+from .sr_wrapper import SuperResolutionWrapper
+
+__all__ = ["ClassifierWrapper", "SuperResolutionWrapper"]

--- a/DiffBreak/utils/sr_wrapper.py
+++ b/DiffBreak/utils/sr_wrapper.py
@@ -1,0 +1,52 @@
+import torch
+from torchvision import transforms
+from diffusers import LDMSuperResolutionPipeline
+
+from .wrapper import ClassifierWrapper
+
+
+class SuperResolutionWrapper(ClassifierWrapper):
+    """Wrap a classifier with an LDM Super Resolution purification step."""
+
+    def __init__(
+        self,
+        model_fn,
+        model_loss,
+        cache_dir="cache",
+        num_inference_steps=100,
+        eta=1.0,
+        eval_mode="batch",
+        verbose=0,
+    ):
+        super().__init__(model_fn, model_loss, eval_mode=eval_mode, verbose=verbose)
+        self.cache_dir = cache_dir
+        self.num_inference_steps = num_inference_steps
+        self.eta = eta
+        self.pipeline = None
+
+    def to(self, device):
+        super().to(device)
+        if self.pipeline is None:
+            self.pipeline = LDMSuperResolutionPipeline.from_pretrained(
+                "CompVis/ldm-super-resolution-4x-openimages",
+                torch_dtype=torch.float16,
+                cache_dir=self.cache_dir,
+                local_files_only=True,
+            ).to(device)
+        else:
+            self.pipeline = self.pipeline.to(device)
+        return self
+
+    def preprocess_eval(self, x):
+        pil_images = [transforms.ToPILImage()(img.cpu()) for img in x]
+        sr_images = []
+        for im in pil_images:
+            with torch.no_grad():
+                sr = self.pipeline(
+                    im, num_inference_steps=self.num_inference_steps, eta=self.eta
+                ).images[0]
+            sr_images.append(transforms.ToTensor()(sr))
+        return torch.stack(sr_images, dim=0).to(x.device)
+
+    def preprocess_forward(self, x, steps=None):
+        return self.preprocess_eval(x)

--- a/docs/registry.py
+++ b/docs/registry.py
@@ -165,7 +165,7 @@ command_desc_map = {
     "attacks": "Lists all attacks offered by DiffBreak.",
     "losses": "Lists all loss functions you can use in your attacks.",
     "grad_modes": "Lists all gradient modes available in DiffBreak.",
-    "custom classifier|dm_class|dataset": "Provides an explanation regarding the use of a custom classifier, dm_class or dataset.",
+    "custom classifier|dm_class|dataset|defense": "Provides an explanation regarding the use of a custom classifier, dm_class, dataset or defense.",
 }
 
 loss_function_map = {
@@ -571,10 +571,18 @@ def make_custom_classifier_card():
     return make_code_card(message, resource_path)
 
 
+def make_custom_defense_card():
+    resource_file = "defense_subclass.txt"
+    message = "[bold green]Providing a custom defense\n"
+    with resources.path(resource_module, resource_file) as fspath:
+        resource_path = fspath.as_posix()
+    return make_code_card(message, resource_path)
+
+
 def make_custom_cards(ctype):
-    if ctype not in ["dataset", "dm_class", "classifier"]:
+    if ctype not in ["dataset", "dm_class", "classifier", "defense"]:
         logging.error(
-            "Custom implementations are only available for dataset|classifier|dm_class."
+            "Custom implementations are only available for dataset|classifier|dm_class|defense."
         )
         exit(1)
 
@@ -582,6 +590,8 @@ def make_custom_cards(ctype):
         return make_data_subclass_card()
     if ctype == "dm_class":
         return make_dm_subclass_card()
+    if ctype == "defense":
+        return make_custom_defense_card()
     return make_custom_classifier_card()
 
 

--- a/docs/snippets/defense_subclass.txt
+++ b/docs/snippets/defense_subclass.txt
@@ -1,0 +1,13 @@
+from DiffBreak.utils import SuperResolutionWrapper
+
+# Wrap your classifier with the super resolution defense
+# `classifier` is an instantiated PyTorch or TF classifier
+# `loss_fn` is a DiffBreak loss such as CE or MarginLoss
+
+defender = SuperResolutionWrapper(
+    classifier,
+    loss_fn,
+    cache_dir="cache",
+    num_inference_steps=100,
+    eta=1.0,
+)


### PR DESCRIPTION
## Summary
- add `SuperResolutionWrapper` for LDM-based super resolution defense
- export new wrapper via utils
- document custom defense snippet
- extend docs registry to include custom defense help

## Testing
- `python -m py_compile DiffBreak/utils/sr_wrapper.py`
- `python -m py_compile docs/registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68409bb0f86c8330a5d0e04603f9560e